### PR TITLE
refactor: bounded LRU session cache and shared middleware helpers

- Replace unbounded _session_cache dict with @lru_cache(maxsize=256)
  to prevent memory growth in long-running universal-mode servers
- Extract _parse_auth_header() and _send_401() module-level helpers to
  eliminate code duplication between _BearerAuthMiddleware and
  _UniversalCredentialMiddleware
- Add type hints to middleware __init__ app parameters and scope/receive/send
- Standardize both middlewares to use early-return on non-HTTP scope

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
 dependencies = [
+    "cachetools>=7.0.5",
     "mcp[cli]>=1.9.4",
     "smartschool",
 ]
@@ -36,6 +37,7 @@ dev = [
     "black>=24.0",
     "ruff>=0.4.0",
     "mypy>=1.10",
+    "types-cachetools>=6.2.0.20260317",
 ]
 
 [project.urls]

--- a/smartschool_mcp/__main__.py
+++ b/smartschool_mcp/__main__.py
@@ -35,14 +35,40 @@ import hmac
 import json
 import logging
 import os
+import re
 from typing import Any
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlparse
 
 from smartschool import AppCredentials
 
 from smartschool_mcp.server import _request_creds, mcp
 
 _logger = logging.getLogger(__name__)
+
+# Valid hostname: dot-separated labels of letters/digits/hyphens.
+_HOSTNAME_RE = re.compile(
+    r"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$"
+)
+
+
+def _validate_school_url(raw: str) -> str | None:
+    """Normalise and validate a school URL from the query string.
+
+    Strips the scheme and trailing slashes so the caller always receives a
+    bare ``hostname`` (or ``hostname:port``) string.  Returns ``None`` if the
+    value does not look like a valid hostname, preventing attacker-controlled
+    URL injection into ``AppCredentials``.
+    """
+    # Add a scheme if missing so urlparse works correctly.
+    candidate = raw if "://" in raw else f"https://{raw}"
+    try:
+        parsed = urlparse(candidate)
+        host = parsed.hostname or ""
+    except Exception:
+        return None
+    if not host or not _HOSTNAME_RE.match(host):
+        return None
+    return host if not parsed.port else f"{host}:{parsed.port}"
 
 
 def main() -> None:
@@ -195,7 +221,8 @@ class _UniversalCredentialMiddleware:
             return
 
         qs = parse_qs(scope.get("query_string", b"").decode())
-        school = (qs.get("school") or [None])[0]
+        raw_school = (qs.get("school") or [""])[0]
+        school = _validate_school_url(raw_school) if raw_school else None
         mfa = (qs.get("mfa") or [""])[0]
 
         auth_bytes = _parse_auth_header(scope)

--- a/smartschool_mcp/__main__.py
+++ b/smartschool_mcp/__main__.py
@@ -10,17 +10,36 @@ Environment variables (all overridable by CLI flags):
   MCP_TRANSPORT   stdio | streamable-http  (default: stdio)
   MCP_HOST        bind address for HTTP    (default: 0.0.0.0)
   MCP_PORT        port for HTTP            (default: 8000)
-  MCP_API_KEY     optional Bearer token required on every HTTP request
+  MCP_API_KEY     optional Bearer token (single-user mode only)
+  MCP_UNIVERSAL   set to 1 to enable universal mode
+
+Universal mode (--universal / MCP_UNIVERSAL=1):
+  One server instance serves any Smartschool user.  Pass credentials on
+  every request instead of baking them into the server environment:
+
+    URL query params:   ?school=school.smartschool.be&mfa=2000-01-15
+    Authorization header: Basic base64(username:password)
+
+  In claude.ai → Settings → Integrations, configure the integration URL
+  with the school and mfa query params, and supply your Smartschool
+  username as the client_id and password as the client_secret (these are
+  forwarded as HTTP Basic auth).  MFA is your date of birth (YYYY-MM-DD);
+  omit it if your account does not require verification.
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
 import hmac
+import json
 import os
 from typing import Any
+from urllib.parse import parse_qs
 
-from smartschool_mcp.server import mcp
+from smartschool import AppCredentials
+
+from smartschool_mcp.server import _request_creds, mcp
 
 
 def main() -> None:
@@ -53,15 +72,24 @@ def main() -> None:
         default=os.environ.get("MCP_PORT", "8000"),
         help="Bind port for HTTP transport (default: 8000)",
     )
+    parser.add_argument(
+        "--universal",
+        action="store_true",
+        default=os.environ.get("MCP_UNIVERSAL", "").lower() in ("1", "true", "yes"),
+        help=(
+            "Universal mode: accept per-request credentials via "
+            "?school=&mfa= query params and Authorization: Basic header"
+        ),
+    )
     args = parser.parse_args()
 
     if args.transport == "streamable-http":
-        _run_http(args.host, args.port)
+        _run_http(args.host, args.port, universal=args.universal)
     else:
         mcp.run()
 
 
-def _run_http(host: str, port: int) -> None:
+def _run_http(host: str, port: int, universal: bool = False) -> None:
     """Run the MCP server over Streamable HTTP (for remote clients / claude.ai).
 
     The MCP endpoint will be available at:
@@ -81,8 +109,27 @@ def _run_http(host: str, port: int) -> None:
     # The ASGI app exposes a single endpoint at /mcp (POST + GET).
     app: Any = mcp.streamable_http_app()
 
+    if universal:
+        # Universal mode: credentials come from each request, not from env vars.
+        app = _UniversalCredentialMiddleware(app)
+        print("[smartschool-mcp] Universal mode enabled")
+        print(
+            "[smartschool-mcp] Pass ?school=<url>&mfa=<dob> in the URL "
+            "and credentials via Authorization: Basic"
+        )
+    else:
+        # Optional Bearer-token guard.  Set MCP_API_KEY to enable.
+        api_key = os.environ.get("MCP_API_KEY")
+        if api_key:
+            app = _BearerAuthMiddleware(app, api_key)
+            print(
+                "[smartschool-mcp] Bearer auth enabled - "
+                "set Authorization: Bearer <MCP_API_KEY>"
+            )
+
     # CORS is required so browser-based clients (including claude.ai) can read
     # the Mcp-Session-Id header returned during initialisation.
+    # Wrap outermost so CORS preflight OPTIONS is handled before auth.
     app = CORSMiddleware(
         app,
         allow_origins=["*"],  # tighten to specific origins in production
@@ -91,17 +138,90 @@ def _run_http(host: str, port: int) -> None:
         expose_headers=["Mcp-Session-Id"],
     )
 
-    # Optional Bearer-token guard.  Set MCP_API_KEY to enable.
-    api_key = os.environ.get("MCP_API_KEY")
-    if api_key:
-        app = _BearerAuthMiddleware(app, api_key)
-        print(
-            "[smartschool-mcp] Bearer auth enabled - "
-            "set Authorization: Bearer <MCP_API_KEY>"
-        )
-
     print(f"[smartschool-mcp] Listening on http://{host}:{port}/mcp")
     uvicorn.run(app, host=host, port=port)
+
+
+class _UniversalCredentialMiddleware:
+    """ASGI middleware for universal (multi-user) mode.
+
+    Extracts Smartschool credentials from each HTTP request so that a single
+    hosted server instance can serve any Smartschool user:
+
+    - ``school`` and ``mfa`` are read from URL query parameters.
+    - ``username`` and ``password`` are read from an ``Authorization: Basic``
+      header (standard HTTP Basic auth, base64-encoded ``username:password``).
+
+    In claude.ai, configure the integration URL with the school and mfa query
+    params, and supply your Smartschool username as the client_id and password
+    as the client_secret (forwarded as HTTP Basic auth).
+    """
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # CORS preflight passes through without auth.
+        if scope.get("method", "").upper() == "OPTIONS":
+            await self.app(scope, receive, send)
+            return
+
+        # Parse school + mfa from query string.
+        qs = parse_qs(scope.get("query_string", b"").decode())
+        school = (qs.get("school") or [None])[0]
+        mfa = (qs.get("mfa") or [""])[0]
+
+        # Parse username + password from Basic auth header.
+        headers = {k.lower(): v for k, v in scope.get("headers", [])}
+        auth_bytes = headers.get(b"authorization", b"")
+        username = password = None
+        if auth_bytes[:6].lower() == b"basic ":
+            try:
+                decoded = base64.b64decode(auth_bytes[6:]).decode()
+                if ":" in decoded:
+                    username, password = decoded.split(":", 1)
+            except Exception:
+                pass
+
+        if not school or not username or not password:
+            await self._reject(
+                send,
+                "Provide ?school=<url> in the URL and credentials "
+                "via Authorization: Basic <base64(username:password)>",
+            )
+            return
+
+        token = _request_creds.set(
+            AppCredentials(
+                username=username,
+                password=password,
+                main_url=school,
+                mfa=mfa,
+            )
+        )
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            _request_creds.reset(token)
+
+    @staticmethod
+    async def _reject(send, message: str) -> None:
+        body = json.dumps({"error": message}).encode()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [
+                    [b"content-type", b"application/json"],
+                    [b"www-authenticate", b'Basic realm="Smartschool MCP"'],
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
 
 
 class _BearerAuthMiddleware:

--- a/smartschool_mcp/__main__.py
+++ b/smartschool_mcp/__main__.py
@@ -142,6 +142,28 @@ def _run_http(host: str, port: int, universal: bool = False) -> None:
     uvicorn.run(app, host=host, port=port)
 
 
+def _parse_auth_header(scope: dict) -> bytes:
+    """Extract the raw Authorization header bytes from an ASGI scope."""
+    headers: dict[bytes, bytes] = {k.lower(): v for k, v in scope.get("headers", [])}
+    return headers.get(b"authorization", b"")
+
+
+async def _send_401(send, www_authenticate: bytes, message: str) -> None:
+    """Send a JSON 401 response with the given WWW-Authenticate challenge."""
+    body = json.dumps({"error": message}).encode()
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 401,
+            "headers": [
+                [b"content-type", b"application/json"],
+                [b"www-authenticate", www_authenticate],
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
 class _UniversalCredentialMiddleware:
     """ASGI middleware for universal (multi-user) mode.
 
@@ -157,27 +179,23 @@ class _UniversalCredentialMiddleware:
     as the client_secret (forwarded as HTTP Basic auth).
     """
 
-    def __init__(self, app) -> None:
+    def __init__(self, app: Any) -> None:
         self.app = app
 
-    async def __call__(self, scope, receive, send) -> None:
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
 
-        # CORS preflight passes through without auth.
         if scope.get("method", "").upper() == "OPTIONS":
             await self.app(scope, receive, send)
             return
 
-        # Parse school + mfa from query string.
         qs = parse_qs(scope.get("query_string", b"").decode())
         school = (qs.get("school") or [None])[0]
         mfa = (qs.get("mfa") or [""])[0]
 
-        # Parse username + password from Basic auth header.
-        headers = {k.lower(): v for k, v in scope.get("headers", [])}
-        auth_bytes = headers.get(b"authorization", b"")
+        auth_bytes = _parse_auth_header(scope)
         username = password = None
         if auth_bytes[:6].lower() == b"basic ":
             try:
@@ -188,8 +206,9 @@ class _UniversalCredentialMiddleware:
                 pass
 
         if not school or not username or not password:
-            await self._reject(
+            await _send_401(
                 send,
+                b'Basic realm="Smartschool MCP"',
                 "Provide ?school=<url> in the URL and credentials "
                 "via Authorization: Basic <base64(username:password)>",
             )
@@ -208,58 +227,32 @@ class _UniversalCredentialMiddleware:
         finally:
             _request_creds.reset(token)
 
-    @staticmethod
-    async def _reject(send, message: str) -> None:
-        body = json.dumps({"error": message}).encode()
-        await send(
-            {
-                "type": "http.response.start",
-                "status": 401,
-                "headers": [
-                    [b"content-type", b"application/json"],
-                    [b"www-authenticate", b'Basic realm="Smartschool MCP"'],
-                ],
-            }
-        )
-        await send({"type": "http.response.body", "body": body})
-
 
 class _BearerAuthMiddleware:
     """Minimal ASGI middleware that enforces a static Bearer token."""
 
-    def __init__(self, app, token: str) -> None:
+    def __init__(self, app: Any, token: str) -> None:
         self.app = app
         self.token = token.encode()
 
-    async def __call__(self, scope, receive, send) -> None:
-        if scope["type"] == "http":
-            # Let CORS preflight through so the browser can negotiate headers.
-            if scope.get("method", "").upper() == "OPTIONS":
-                await self.app(scope, receive, send)
-                return
-            headers = {k.lower(): v for k, v in scope.get("headers", [])}
-            auth_bytes = headers.get(b"authorization", b"")
-            if not (
-                auth_bytes[:7].lower() == b"bearer "
-                and hmac.compare_digest(auth_bytes[7:], self.token)
-            ):
-                await self._reject(send)
-                return
-        await self.app(scope, receive, send)
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
 
-    @staticmethod
-    async def _reject(send) -> None:
-        await send(
-            {
-                "type": "http.response.start",
-                "status": 401,
-                "headers": [
-                    [b"content-type", b"application/json"],
-                    [b"www-authenticate", b'Bearer realm="Smartschool MCP"'],
-                ],
-            }
-        )
-        await send({"type": "http.response.body", "body": b'{"error":"Unauthorized"}'})
+        if scope.get("method", "").upper() == "OPTIONS":
+            await self.app(scope, receive, send)
+            return
+
+        auth_bytes = _parse_auth_header(scope)
+        if not (
+            auth_bytes[:7].lower() == b"bearer "
+            and hmac.compare_digest(auth_bytes[7:], self.token)
+        ):
+            await _send_401(send, b'Bearer realm="Smartschool MCP"', "Unauthorized")
+            return
+
+        await self.app(scope, receive, send)
 
 
 if __name__ == "__main__":

--- a/smartschool_mcp/__main__.py
+++ b/smartschool_mcp/__main__.py
@@ -33,6 +33,7 @@ import argparse
 import base64
 import hmac
 import json
+import logging
 import os
 from typing import Any
 from urllib.parse import parse_qs
@@ -40,6 +41,8 @@ from urllib.parse import parse_qs
 from smartschool import AppCredentials
 
 from smartschool_mcp.server import _request_creds, mcp
+
+_logger = logging.getLogger(__name__)
 
 
 def main() -> None:
@@ -202,8 +205,8 @@ class _UniversalCredentialMiddleware:
                 decoded = base64.b64decode(auth_bytes[6:]).decode()
                 if ":" in decoded:
                     username, password = decoded.split(":", 1)
-            except Exception:
-                pass
+            except Exception as e:
+                _logger.debug("Failed to decode Basic auth header: %s", e)
 
         if not school or not username or not password:
             await _send_401(

--- a/smartschool_mcp/server.py
+++ b/smartschool_mcp/server.py
@@ -6,11 +6,14 @@ messages and more.
 
 from __future__ import annotations
 
+import os
+import threading
 from contextvars import ContextVar
 from datetime import date, timedelta
 from functools import lru_cache
 from typing import Any, TypedDict
 
+from cachetools import TTLCache, cached
 from mcp.server.fastmcp import FastMCP
 from smartschool import (
     AppCredentials,
@@ -50,14 +53,26 @@ def _env_session() -> Smartschool:
     return Smartschool(EnvCredentials())
 
 
-@lru_cache(maxsize=256)
+# How long (seconds) a cached Smartschool session is reused before the next
+# request for those credentials creates a fresh one.  Cookie-based sessions
+# expire server-side; keeping this below the server's idle-session timeout
+# prevents stale-cookie failures.  Override with SESSION_TTL_SECONDS env var.
+_SESSION_TTL_SECONDS = int(os.environ.get("SESSION_TTL_SECONDS", "3600"))
+_session_cache: TTLCache[tuple[str, str, str, str], Smartschool] = TTLCache(
+    maxsize=256, ttl=_SESSION_TTL_SECONDS
+)
+_session_cache_lock = threading.Lock()
+
+
+@cached(cache=_session_cache, lock=_session_cache_lock)
 def _cached_app_session(
     username: str, password: str, main_url: str, mfa: str
 ) -> Smartschool:
-    """LRU-cached session per unique credential tuple (universal mode).
+    """TTL-cached session per unique credential tuple (universal mode).
 
-    Bounded to 256 entries so a long-running server does not accumulate
-    unbounded Smartschool session objects.
+    Entries expire after SESSION_TTL_SECONDS (default 3600) so stale cookies
+    from server-side session expiry are automatically replaced.  Bounded to
+    256 entries to cap memory use.
     """
     return Smartschool(
         AppCredentials(username=username, password=password, main_url=main_url, mfa=mfa)

--- a/smartschool_mcp/server.py
+++ b/smartschool_mcp/server.py
@@ -6,12 +6,14 @@ messages and more.
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from datetime import date, timedelta
 from functools import lru_cache
 from typing import Any, TypedDict
 
 from mcp.server.fastmcp import FastMCP
 from smartschool import (
+    AppCredentials,
     Attachments,
     BoxType,
     Courses,
@@ -31,16 +33,41 @@ from smartschool import (
 # MCP server - tools are registered via @mcp.tool() decorators below
 mcp = FastMCP("Smartschool MCP")
 
+# Per-request credentials, set by _UniversalCredentialMiddleware in universal mode.
+_request_creds: ContextVar[AppCredentials | None] = ContextVar(
+    "_request_creds", default=None
+)
+
+# Session cache keyed by (username, password, main_url, mfa) for universal mode.
+_session_cache: dict[tuple[str, str, str, str], Smartschool] = {}
+
 
 @lru_cache(maxsize=1)
-def _session() -> Smartschool:
-    """Create and cache the Smartschool session.
+def _env_session() -> Smartschool:
+    """Cached session using environment-variable credentials (single-user mode).
 
     Lazy-initialized on first tool invocation so that import-time errors
     (missing env vars, network failures) surface as tool errors rather than
     crashing the process on startup.
     """
     return Smartschool(EnvCredentials())
+
+
+def _session() -> Smartschool:
+    """Return the active Smartschool session.
+
+    In universal mode a per-request AppCredentials object is stored in
+    _request_creds; sessions are cached per unique credentials tuple so that
+    repeated calls reuse the same authenticated session (and its cookie cache).
+    Falls back to the environment-variable session in single-user / stdio mode.
+    """
+    creds = _request_creds.get()
+    if creds is None:
+        return _env_session()
+    key = (creds.username, creds.password, creds.main_url, creds.mfa)
+    if key not in _session_cache:
+        _session_cache[key] = Smartschool(creds)
+    return _session_cache[key]
 
 
 def _safe_get_teacher_names(

--- a/smartschool_mcp/server.py
+++ b/smartschool_mcp/server.py
@@ -38,9 +38,6 @@ _request_creds: ContextVar[AppCredentials | None] = ContextVar(
     "_request_creds", default=None
 )
 
-# Session cache keyed by (username, password, main_url, mfa) for universal mode.
-_session_cache: dict[tuple[str, str, str, str], Smartschool] = {}
-
 
 @lru_cache(maxsize=1)
 def _env_session() -> Smartschool:
@@ -51,6 +48,20 @@ def _env_session() -> Smartschool:
     crashing the process on startup.
     """
     return Smartschool(EnvCredentials())
+
+
+@lru_cache(maxsize=256)
+def _cached_app_session(
+    username: str, password: str, main_url: str, mfa: str
+) -> Smartschool:
+    """LRU-cached session per unique credential tuple (universal mode).
+
+    Bounded to 256 entries so a long-running server does not accumulate
+    unbounded Smartschool session objects.
+    """
+    return Smartschool(
+        AppCredentials(username=username, password=password, main_url=main_url, mfa=mfa)
+    )
 
 
 def _session() -> Smartschool:
@@ -64,10 +75,9 @@ def _session() -> Smartschool:
     creds = _request_creds.get()
     if creds is None:
         return _env_session()
-    key = (creds.username, creds.password, creds.main_url, creds.mfa)
-    if key not in _session_cache:
-        _session_cache[key] = Smartschool(creds)
-    return _session_cache[key]
+    return _cached_app_session(
+        creds.username, creds.password, creds.main_url, creds.mfa
+    )
 
 
 def _safe_get_teacher_names(

--- a/tests/test_universal.py
+++ b/tests/test_universal.py
@@ -1,4 +1,4 @@
-"""Tests for _UniversalCredentialMiddleware."""
+"""Tests for _UniversalCredentialMiddleware and helpers."""
 
 from __future__ import annotations
 
@@ -8,7 +8,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from smartschool_mcp.__main__ import _UniversalCredentialMiddleware
+from smartschool_mcp.__main__ import (
+    _UniversalCredentialMiddleware,
+    _validate_school_url,
+)
 from smartschool_mcp.server import _request_creds
 
 
@@ -179,3 +182,49 @@ async def test_request_creds_cleared_after_request() -> None:
     mw = _UniversalCredentialMiddleware(AsyncMock())
     await mw(scope, AsyncMock(), AsyncMock())
     assert _request_creds.get() is None
+
+
+# ── _validate_school_url ──────────────────────────────────────────────────────
+
+
+def test_validate_school_url_bare_hostname() -> None:
+    assert _validate_school_url("school.smartschool.be") == "school.smartschool.be"
+
+
+def test_validate_school_url_strips_scheme() -> None:
+    result = _validate_school_url("https://school.smartschool.be")
+    assert result == "school.smartschool.be"
+
+
+def test_validate_school_url_strips_trailing_slash() -> None:
+    result = _validate_school_url("https://school.smartschool.be/")
+    assert result == "school.smartschool.be"
+
+
+def test_validate_school_url_preserves_port() -> None:
+    result = _validate_school_url("school.smartschool.be:8443")
+    assert result == "school.smartschool.be:8443"
+
+
+def test_validate_school_url_rejects_ip_address() -> None:
+    assert _validate_school_url("192.168.1.1") is None
+
+
+def test_validate_school_url_rejects_empty() -> None:
+    assert _validate_school_url("") is None
+
+
+def test_validate_school_url_strips_path_safely() -> None:
+    # urlparse isolates the hostname; the path is discarded, not forwarded.
+    assert _validate_school_url("evil.com/../../etc/passwd") == "evil.com"
+
+
+@pytest.mark.asyncio
+async def test_invalid_school_url_returns_401() -> None:
+    scope = _make_scope(
+        query_string=b"school=not-a-valid..hostname",
+        headers=_basic("user", "pass"),
+    )
+    messages = await _run(scope)
+    start = next(m for m in messages if m.get("type") == "http.response.start")
+    assert start["status"] == 401

--- a/tests/test_universal.py
+++ b/tests/test_universal.py
@@ -1,0 +1,181 @@
+"""Tests for _UniversalCredentialMiddleware."""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from smartschool_mcp.__main__ import _UniversalCredentialMiddleware
+from smartschool_mcp.server import _request_creds
+
+
+def _make_scope(
+    method: str = "POST",
+    query_string: bytes = b"",
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> dict:
+    return {
+        "type": "http",
+        "method": method,
+        "query_string": query_string,
+        "headers": headers or [],
+    }
+
+
+def _basic(username: str, password: str) -> list[tuple[bytes, bytes]]:
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return [(b"authorization", f"Basic {token}".encode())]
+
+
+def _qs(school: str, mfa: str = "") -> bytes:
+    q = f"school={school}"
+    if mfa:
+        q += f"&mfa={mfa}"
+    return q.encode()
+
+
+async def _run(scope) -> list[dict]:
+    """Run the middleware with a no-op inner app; return all ASGI messages."""
+    messages: list[dict] = []
+
+    async def send(msg: dict) -> None:
+        messages.append(msg)
+
+    async def app(s, r, se) -> None:
+        await se({"type": "http.response.start", "status": 200, "headers": []})
+        await se({"type": "http.response.body", "body": b"ok"})
+
+    mw = _UniversalCredentialMiddleware(app)
+    await mw(scope, AsyncMock(), send)
+    return messages
+
+
+# ── Rejection cases ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_school_returns_401() -> None:
+    scope = _make_scope(headers=_basic("user", "pass"))
+    messages = await _run(scope)
+    start = next(m for m in messages if m.get("type") == "http.response.start")
+    assert start["status"] == 401
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_returns_401() -> None:
+    scope = _make_scope(query_string=_qs("school.smartschool.be"))
+    messages = await _run(scope)
+    start = next(m for m in messages if m.get("type") == "http.response.start")
+    assert start["status"] == 401
+
+
+@pytest.mark.asyncio
+async def test_malformed_basic_auth_returns_401() -> None:
+    # Base64 of something without a colon
+    bad = base64.b64encode(b"nocolon").decode()
+    scope = _make_scope(
+        query_string=_qs("school.smartschool.be"),
+        headers=[(b"authorization", f"Basic {bad}".encode())],
+    )
+    messages = await _run(scope)
+    start = next(m for m in messages if m.get("type") == "http.response.start")
+    assert start["status"] == 401
+
+
+@pytest.mark.asyncio
+async def test_401_body_contains_error_key() -> None:
+    scope = _make_scope()
+    messages = await _run(scope)
+    body_msg = next(m for m in messages if m.get("type") == "http.response.body")
+    payload = json.loads(body_msg["body"])
+    assert "error" in payload
+
+
+# ── Pass-through cases ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_valid_credentials_returns_200() -> None:
+    scope = _make_scope(
+        query_string=_qs("school.smartschool.be", "2000-01-15"),
+        headers=_basic("user", "pass"),
+    )
+    messages = await _run(scope)
+    start = next(m for m in messages if m.get("type") == "http.response.start")
+    assert start["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_mfa_is_optional() -> None:
+    scope = _make_scope(
+        query_string=_qs("school.smartschool.be"),  # no mfa
+        headers=_basic("user", "pass"),
+    )
+    messages = await _run(scope)
+    start = next(m for m in messages if m.get("type") == "http.response.start")
+    assert start["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_options_bypasses_auth() -> None:
+    scope = _make_scope(method="OPTIONS")  # no school, no credentials
+    messages = await _run(scope)
+    start = next(m for m in messages if m.get("type") == "http.response.start")
+    assert start["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_non_http_scope_bypasses_auth() -> None:
+    scope = {"type": "lifespan"}
+    received: list[str] = []
+
+    async def app(s, r, se) -> None:
+        received.append(s["type"])
+
+    mw = _UniversalCredentialMiddleware(app)
+    await mw(scope, AsyncMock(), AsyncMock())
+    assert "lifespan" in received
+
+
+# ── Contextvar is set correctly ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_request_creds_set_during_request() -> None:
+    scope = _make_scope(
+        query_string=_qs("myschool.smartschool.be", "1999-12-31"),
+        headers=_basic("alice", "s3cr3t"),
+    )
+    captured: list = []
+
+    async def app(s, r, se) -> None:
+        captured.append(_request_creds.get())
+        await se({"type": "http.response.start", "status": 200, "headers": []})
+        await se({"type": "http.response.body", "body": b""})
+
+    from smartschool import AppCredentials
+
+    mw = _UniversalCredentialMiddleware(app)
+    await mw(scope, AsyncMock(), AsyncMock())
+
+    assert len(captured) == 1
+    creds = captured[0]
+    assert isinstance(creds, AppCredentials)
+    assert creds.username == "alice"
+    assert creds.password == "s3cr3t"
+    assert creds.main_url == "myschool.smartschool.be"
+    assert creds.mfa == "1999-12-31"
+
+
+@pytest.mark.asyncio
+async def test_request_creds_cleared_after_request() -> None:
+    scope = _make_scope(
+        query_string=_qs("school.smartschool.be"),
+        headers=_basic("user", "pass"),
+    )
+    mw = _UniversalCredentialMiddleware(AsyncMock())
+    await mw(scope, AsyncMock(), AsyncMock())
+    assert _request_creds.get() is None

--- a/tests/test_universal.py
+++ b/tests/test_universal.py
@@ -89,6 +89,17 @@ async def test_malformed_basic_auth_returns_401() -> None:
 
 
 @pytest.mark.asyncio
+async def test_invalid_base64_auth_returns_401() -> None:
+    scope = _make_scope(
+        query_string=_qs("school.smartschool.be"),
+        headers=[(b"authorization", b"Basic !!!")],
+    )
+    messages = await _run(scope)
+    start = next(m for m in messages if m.get("type") == "http.response.start")
+    assert start["status"] == 401
+
+
+@pytest.mark.asyncio
 async def test_401_body_contains_error_key() -> None:
     scope = _make_scope()
     messages = await _run(scope)

--- a/uv.lock
+++ b/uv.lock
@@ -122,6 +122,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/dd/57fe3fdb6e65b25a5987fd2cdc7e22db0aef508b91634d2e57d22928d41b/cachetools-7.0.5.tar.gz", hash = "sha256:0cd042c24377200c1dcd225f8b7b12b0ca53cc2c961b43757e774ebe190fd990", size = 37367, upload-time = "2026-03-09T20:51:29.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/f3/39cf3367b8107baa44f861dc802cbf16263c945b62d8265d36034fc07bea/cachetools-7.0.5-py3-none-any.whl", hash = "sha256:46bc8ebefbe485407621d0a4264b23c080cedd913921bad7ac3ed2f26c183114", size = 13918, upload-time = "2026-03-09T20:51:27.33Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.6.15"
 source = { registry = "https://pypi.org/simple" }
@@ -1039,6 +1048,7 @@ name = "smartschool-mcp"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "cachetools" },
     { name = "mcp", extra = ["cli"] },
     { name = "smartschool" },
 ]
@@ -1051,11 +1061,13 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-cachetools" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0" },
+    { name = "cachetools", specifier = ">=7.0.5" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.4" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -1063,6 +1075,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "smartschool", git = "https://github.com/svaningelgem/smartschool.git" },
+    { name = "types-cachetools", marker = "extra == 'dev'", specifier = ">=6.2.0.20260317" },
 ]
 provides-extras = ["dev"]
 
@@ -1176,6 +1189,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
+]
+
+[[package]]
+name = "types-cachetools"
+version = "6.2.0.20260317"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/7f/16a4d8344c28193a5a74358028c2d2f753f0d9658dd98b9e1967c50045a2/types_cachetools-6.2.0.20260317.tar.gz", hash = "sha256:6d91855bcc944665897c125e720aa3c80aace929b77a64e796343701df4f61c6", size = 9812, upload-time = "2026-03-17T04:06:32.007Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/9a/b00b23054934c4d569c19f7278c4fb32746cd36a64a175a216d3073a4713/types_cachetools-6.2.0.20260317-py3-none-any.whl", hash = "sha256:92fa9bc50e4629e31fca67ceb3fb1de71791e314fa16c0a0d2728724dc222c8b", size = 9346, upload-time = "2026-03-17T04:06:31.184Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

<!-- Describe what this PR changes and why. Link the relevant issue(s). -->

Closes #

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behaviour)
- [ ] 🧹 Refactor / internal improvement (no behaviour change)
- [ ] 📝 Documentation update
- [ ] ⬆️ Dependency update
- [ ] 🔧 CI / tooling

---

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] `ruff check .` and `ruff format --check .` pass locally
- [ ] `mypy smartschool_mcp/` passes locally
- [ ] `pytest` passes locally
- [ ] New or changed behaviour is covered by tests
- [ ] I have updated `CHANGELOG.md` under `[Unreleased]`
- [ ] I have updated the documentation / README if necessary
- [ ] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
  (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`)

---

## Testing

<!-- Describe how you verified your changes. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Universal auth mode: per-request credentials via query params and Basic auth with standardized 401 JSON + WWW-Authenticate challenge.

* **Improvements**
  * Dynamic session handling with per-credential caching and environment fallback; middleware ordering adjusted to preserve CORS and OPTIONS behavior.

* **Tests**
  * New tests covering universal auth flows, credential lifecycle, OPTIONS pass-through, and validation of provided school URLs.

* **Chores**
  * Added cachetools runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->